### PR TITLE
Fix/[T8-458] fix filled formCard issues

### DIFF
--- a/src/components/FormCard.tsx
+++ b/src/components/FormCard.tsx
@@ -48,13 +48,13 @@ const FormCard = ({ chainId }: FormCardProps) => {
 
   const plainOptions = ['Skip pending', 'Skip suspisious']
 
-  const addSweepAmountTotal = (amount: string) => {
+  const addSweepAmountTotal = (amount: number) => {
     if (!sweepTokens?.length) return
 
     let total = 0
     let totalItems = 0
     for (const token of sweepTokens || []) {
-      if (Number(amount) > 0 && total + Number(token?.market?.floorAsk?.price?.amount?.native) > Number(amount)) break
+      if (amount > 0 && total + Number(token?.market?.floorAsk?.price?.amount?.native) > amount) break
 
       total += Number(token.market?.floorAsk?.price?.amount?.native)
       totalItems += 1
@@ -91,10 +91,10 @@ const FormCard = ({ chainId }: FormCardProps) => {
   const handleEthAmount = (e: React.ChangeEvent<HTMLInputElement>) => {
     e.preventDefault()
 
-    const amount = e.target.value.trim()
+    const amount = e.target.value.replace(/[^0-9.]/g, '').trim()
     setEthAmount(amount)
 
-    addSweepAmountTotal(amount)
+    addSweepAmountTotal(Number(amount))
   }
   const handleSweepChangeAmount = (value: number) => {
     setSweepAmount(value)
@@ -202,7 +202,6 @@ const FormCard = ({ chainId }: FormCardProps) => {
                     <InputWithoutBorder
                       style={{ color: 'var(--gray-7)', padding: '0' }}
                       bordered={false}
-                      type='number'
                       value={ethAmount}
                       onChange={handleEthAmount}
                     />

--- a/src/components/FormCard.tsx
+++ b/src/components/FormCard.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import React, { useEffect, useState } from 'react'
 import { Button, Card, Col, Checkbox, Form, Input, Image, Row, Typography, Alert, Tooltip } from 'antd'
 import styled from 'styled-components'
 import { CollectionImage } from '@components/shared/CollectionImage'
@@ -48,13 +48,13 @@ const FormCard = ({ chainId }: FormCardProps) => {
 
   const plainOptions = ['Skip pending', 'Skip suspisious']
 
-  const addSweepAmountTotal = (amount: number) => {
+  const addSweepAmountTotal = (amount: string) => {
     if (!sweepTokens?.length) return
 
     let total = 0
     let totalItems = 0
     for (const token of sweepTokens || []) {
-      if (amount > 0 && total + Number(token?.market?.floorAsk?.price?.amount?.native) > amount) break
+      if (Number(amount) > 0 && total + Number(token?.market?.floorAsk?.price?.amount?.native) > Number(amount)) break
 
       total += Number(token.market?.floorAsk?.price?.amount?.native)
       totalItems += 1
@@ -87,9 +87,11 @@ const FormCard = ({ chainId }: FormCardProps) => {
   }
 
   const handleSelectCollection = (data: ReservoirCollection | undefined) => setCollectionData(data)
-  const handleEthAmount = e => {
+
+  const handleEthAmount = (e: React.ChangeEvent<HTMLInputElement>) => {
     e.preventDefault()
-    const amount = Number(e.target.value.trim())
+
+    const amount = e.target.value.trim()
     setEthAmount(amount)
 
     addSweepAmountTotal(amount)
@@ -234,7 +236,7 @@ const FormCard = ({ chainId }: FormCardProps) => {
                         <Col style={{ display: 'flex', flexDirection: 'column', justifyContent: 'center' }}>
                           {maxInput >= 1 && (
                             <Link onClick={() => SweepModalVar(true)} style={{ margin: '0 auto' }}>
-                              See NFT
+                              See NFTs
                             </Link>
                           )}
                           {maxInput === 0 ? (
@@ -266,13 +268,10 @@ const FormCard = ({ chainId }: FormCardProps) => {
                       {collectionData ? (
                         <Button size='large' onClick={() => CollectionSelectModalVar(true)}>
                           <Space>
-                            <CollectionImage
+                            <Image
+                              preview={false}
                               src={collectionData?.image}
-                              diameter={24}
-                              address={collectionData?.id}
-                              loading={false}
-                              borderSize='1px'
-                              borderColor='var(--gray-7)'
+                              style={{ borderColor: 'var(--gray-7)', borderWidth: '1px', width: 24, height: 24, borderRadius: 12 }}
                             />
                             &nbsp;
                             <div>
@@ -305,7 +304,7 @@ const FormCard = ({ chainId }: FormCardProps) => {
               </FormItem>
               {!!sweepTotalEth && (
                 <FormItem>
-                  <ProfitAlert type='success' message={`Expected profit: ${expectedProfit?.toFixed(8)}`} />
+                  <ProfitAlert type='success' message={`Expected profit: ${expectedProfit?.toFixed(8)} ETH`} />
                 </FormItem>
               )}
               <FormItem>

--- a/src/hooks/useHandleInputs.tsx
+++ b/src/hooks/useHandleInputs.tsx
@@ -6,7 +6,7 @@ interface InputProps {
   value: string | number;
   valid: boolean;
   reset: Function;
-  onChange: ChangeEventHandler;
+  onChange: (value: string) => void;
   setValue: Dispatch<SetStateAction<string | number>>;
 }
 


### PR DESCRIPTION
![7817a660-24bb-4367-bacf-856873afcca6](https://user-images.githubusercontent.com/82888366/210650494-8b26bbf1-c940-4043-b940-e305def768aa.png)


formatting of decimal places must follow the American standard. That is, to separate units from decimals, a period is used.

The collection image doesn't seem to be fully filling the circle. Notice that in all of them this white piece appears at the top.

It should be NFTs in the plural. And the spacing between the text and the slider seems to be larger than expected in Figma.

In the expected profit, the symbol ETH was missing at the end.